### PR TITLE
Fix buffer to file conversion for transcription

### DIFF
--- a/src/services/transcription.service.js
+++ b/src/services/transcription.service.js
@@ -6,19 +6,12 @@ const openai = new OpenAI({ apiKey: config.openai.apiKey });
 
 async function transcribeAudio(buffer) {
     try {
-        // --- INÍCIO DA CORREÇÃO ---
-        // A API espera um objeto que se pareça com um arquivo.
-        // Nós damos um nome genérico ao arquivo, pois ele é transitório.
-        const audioFile = {
-            file: buffer,
-            name: 'audio.ogg', // O nome é necessário para a API
-        };
-        // --- FIM DA CORREÇÃO ---
+        // Converte o Buffer para um objeto compatível com arquivo antes da chamada
+        // à API. O método `toFile` auxilia na geração do objeto esperado.
+        const file = await OpenAI.toFile(buffer, 'audio.ogg');
 
         const transcription = await openai.audio.transcriptions.create({
-            file: audioFile.file, // Passamos o buffer
-            // A API infere o tipo, mas podemos ser explícitos se necessário.
-            // name: audioFile.name, 
+            file,
             model: 'whisper-1'
         });
 


### PR DESCRIPTION
## Summary
- convert audio buffer to a file object using `OpenAI.toFile`
- pass the file object to the OpenAI transcription API

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_687305b861dc8321b80c566f237563e1