### PR TITLE
Update Node base image to 24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Estágio 1: Builder - Instala dependências e prepara o código
-FROM node:20-slim AS builder
+FROM node:24-slim AS builder
 
 WORKDIR /app
 
@@ -14,7 +14,7 @@ COPY . .
 
 
 # Estágio 2: Production - A imagem final, otimizada e segura
-FROM node:20-slim
+FROM node:24-slim
 
 WORKDIR /app
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "Seu Nome",
   "license": "ISC",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=24.0.0"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.44.2",


### PR DESCRIPTION
## Summary
- upgrade Docker image to `node:24-slim`
- set Node version requirement to `>=24.0.0` in `package.json`

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_68742fbfc3a88321b474f1c5d652069a