### PR TITLE
Add /health endpoint

### DIFF
--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -11,6 +11,11 @@ const clinicRoutes = require('./clinics.routes');
 // Inicializa o roteador principal
 const router = express.Router();
 
+// Endpoint simples para checagem de saúde da aplicação
+router.get('/health', (req, res) => {
+    res.status(200).json({ status: 'ok' });
+});
+
 // Delega as rotas para os seus respectivos handlers
 router.use('/', webhookRoutes);
 router.use('/api/v1/conversations', conversationRoutes);


### PR DESCRIPTION
## Summary
- add a simple GET `/health` route

## Testing
- `npm start` *(fails: ECONNREFUSED to Redis, but server runs)*
- `curl -s -o /tmp/health.txt -w "%{http_code}" http://localhost:3000/health`

------
https://chatgpt.com/codex/tasks/task_e_6874508c86ac832197b143e91f4fe2d1