### PR TITLE
Add SIGINT shutdown handler

### DIFF
--- a/server.js
+++ b/server.js
@@ -32,3 +32,13 @@ process.on('SIGTERM', () => {
         process.exit(0);
     });
 });
+
+process.on('SIGINT', () => {
+    console.log('📴 Recebido SIGINT, iniciando shutdown graceful...');
+    server.close(async () => {
+        const sessionManager = require('./src/services/sessionManager');
+        await sessionManager.close();
+        console.log('Processo finalizado.');
+        process.exit(0);
+    });
+});


### PR DESCRIPTION
## Summary
- ensure the server gracefully shuts down on SIGINT

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687450938a6083219fa9213954cb5d54