### PR TITLE
Handle clinic settings via new table

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-"# meu-bot" 
+# meu-bot
+
+Este repositório contém uma aplicação Node.js que integra WhatsApp, OpenAI e Supabase para automação de atendimento.
+
+## Scripts de banco de dados
+
+Na pasta `sql/` há um script `clinic_settings.sql` que cria a tabela `clinic_settings` e políticas de acesso no Supabase. Execute-o em seu banco para habilitar o armazenamento do `google_calendar_id` de cada clínica.

--- a/sql/clinic_settings.sql
+++ b/sql/clinic_settings.sql
@@ -1,0 +1,32 @@
+-- Criação da tabela de configurações por clínica
+create table public.clinic_settings (
+  clinic_id uuid primary key references public.clinics(id) on delete cascade,
+  google_calendar_id text,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+-- Atualização automática do campo 'updated_at'
+create or replace function update_updated_at_column()
+returns trigger as $$
+begin
+  NEW.updated_at = now();
+  return NEW;
+end;
+$$ language plpgsql;
+
+create trigger set_timestamp
+before update on public.clinic_settings
+for each row
+execute procedure update_updated_at_column();
+
+-- (Opcional) Permitir leitura/edição via policies no Supabase (se usar diretamente no frontend)
+alter table clinic_settings enable row level security;
+
+create policy "Permitir leitura do settings da clínica"
+on clinic_settings for select
+using (clinic_id = (select clinic_id from public.profiles where id = auth.uid()));
+
+create policy "Permitir update do settings da clínica"
+on clinic_settings for update
+using (clinic_id = (select clinic_id from public.profiles where id = auth.uid()));


### PR DESCRIPTION
## Summary
- add SQL script to create `clinic_settings` table and policies
- read Google Calendar ID from `clinic_settings`
- update clinics API route to insert/update `clinic_settings`
- document the new SQL migration in README

## Testing
- `npm install`
- `npm start` *(fails: missing env vars)*

------
https://chatgpt.com/codex/tasks/task_e_6876c5ba232483218d8ea7c3df9ddb11